### PR TITLE
ubidump: parse node before print it

### DIFF
--- a/ubidump.py
+++ b/ubidump.py
@@ -913,6 +913,7 @@ class UbiFs:
         nodedata = self.vol.read(lnum, offs + ch.hdrsize, ch.len - ch.hdrsize)
 
         if crc32(hdrdata[8:] + nodedata) != ch.crc:
+            node.parse(nodedata)
             print(ch, node)
             print(" %s + %s = %08x -> want = %08x" % ( b2a_hex(hdrdata), b2a_hex(nodedata), crc32(hdrdata[8:] + nodedata), ch.crc))
             raise Exception("invalid node crc")


### PR DESCRIPTION
unparsed nodes have no key attribute. So print will fail an  "invalid
node crc" will not be shown.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>