### PR TITLE
fix --savedir error

### DIFF
--- a/ubidump.py
+++ b/ubidump.py
@@ -1317,6 +1317,7 @@ def processvolume(vol, volumename, args):
     if args.savedir:
         savedir = args.savedir.encode(args.encoding)
 
+        os.makedirs(savedir.decode(args.encoding) + '/' + volumename.decode(args.encoding))
         count = 0
         for inum, path in fs.recursefiles(1, [], UbiFsDirEntry.ALL_TYPES, root=root):
             c = fs.find('eq', (inum, UBIFS_INO_KEY, 0))


### PR DESCRIPTION
python3 ubidump.py --savedir fs1  test.img
==> test.img <==
named volumes found, 2 physical volumes, blocksize=0x20000
== volume b'testfs' ==
E: [Errno 2] No such file or directory: b'fs1/fs1/test.txt'
