### PR TITLE
Update README to show all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,22 @@ optional arguments:
 Usage Examples
 --------------
 
-View the contents of the `/etc/passwd` file in the filesystem image `image.ubi`:
+Print the contents of the `/etc/passwd` file in the filesystem image `image.ubi` to `STDOUT`:
 
-    python ubidump.py  -c /etc/passwd  image.ubi
+    python ubidump.py -c /etc/passwd  image.ubi
+
+Extract contents of the filesystem image `image.ubi` to directory `/tmp/foo`:
+
+    python ubidump.py -s /tmp/foo
 
 List the files in all the volumes in `image.ubi`:
 
-    python ubidump.py  -l  image.ubi
+    python ubidump.py -l image.ubi
 
 View the contents of b-tree database from the volumes in `image.ubi`:
 
-    python ubidump.py  -d  image.ubi
+    python ubidump.py -d image.ubi
+
 
 
 Install

--- a/README.md
+++ b/README.md
@@ -40,6 +40,43 @@ with the second modprobe line.
 Usage
 =====
 
+```
+usage: ubidump.py [-h] [--savedir DIRECTORY] [--preserve] [--cat FILE]
+                  [--listfiles] [--dumptree] [--verbose] [--debug]
+                  [--encoding ENCODING] [--masteroffset MASTEROFFSET]
+                  [--root ROOT] [--rawdump] [--volume VOLUME]
+                  [--hexdump LEB:OFF:N] [--nodedump LEB:OFF]
+                  FILES [FILES ...]
+
+UBIFS dumper.
+
+positional arguments:
+  FILES                 list of ubi images to use
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --savedir DIRECTORY, -s DIRECTORY
+                        save files in all volumes to the specified directory
+  --preserve, -p        preserve permissions and timestamps
+  --cat FILE, -c FILE   extract a single file to stdout
+  --listfiles, -l       list directory contents
+  --dumptree, -d        dump the filesystem b-tree contents
+  --verbose, -v         print extra info
+  --debug               abort on exceptions
+  --encoding ENCODING, -e ENCODING
+                        filename encoding, default=utf-8
+  --masteroffset MASTEROFFSET, -m MASTEROFFSET
+                        Which master node to use.
+  --root ROOT, -R ROOT  Which Root node to use (hexlnum:hexoffset).
+  --rawdump             Raw hexdump of entire volume.
+  --volume VOLUME       which volume to hexdump
+  --hexdump LEB:OFF:N   hexdump part of a volume/leb[/ofs[/size]]
+  --nodedump LEB:OFF    dump specific node at volume/leb[/ofs]
+```
+
+Usage Examples
+--------------
+
 View the contents of the `/etc/passwd` file in the filesystem image `image.ubi`:
 
     python ubidump.py  -c /etc/passwd  image.ubi


### PR DESCRIPTION
Adds the output of `ubidump --help` to a "Usage" section of the readme.
- Usage documentation manually wrapped at 80 chars per line

Moves the current "Usage" to "Usage Examples".

Adds a "savedir" example to "Usage Examples"

Removes extraneous spaces from usage examples.

Changes capitalization to be consistent.


I feel that these changes allow consumers to recognize the full potential of ubidump
and provide a better understanding of what the tool can do on first look.

Please review and let me know what I can fix.