### PR TITLE
Use ImportError instead of ModuleNotFoundError

### DIFF
--- a/ubidump.py
+++ b/ubidump.py
@@ -21,7 +21,7 @@ import pkg_resources
 
 try:
     import zstandard as zstd
-except ModuleNotFoundError:
+except ImportError:
     zstd = None
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
This makes the code retro-compatible until at least Python3.5

See e.g. https://github.com/chaostoolkit/chaostoolkit-lib/issues/67 and the fix
https://github.com/chaostoolkit/chaostoolkit-lib/commit/fae7f34e3ccbe8e6eb900d06c0e238fb43861d8d